### PR TITLE
fix: Ensure command stack is initialised

### DIFF
--- a/smart-dash.el
+++ b/smart-dash.el
@@ -398,6 +398,12 @@ non-nil."
 (add-hook 'minibuffer-exit-hook 'smart-dash-minibuffer-exit)
 
 (defun smart-dash-minibuffer-install ()
+  ;; Initialize stacks if they are nil
+  (unless smart-dash-minibuffer-this-command-stack
+    (setq smart-dash-minibuffer-this-command-stack (list this-command)))
+  (unless smart-dash-minibuffer-last-exit-command-stack
+    (setq smart-dash-minibuffer-last-exit-command-stack (list this-command)))
+
   (unless (eq this-command
               (car smart-dash-minibuffer-last-exit-command-stack))
     (rplaca smart-dash-minibuffer-this-command-stack this-command))


### PR DESCRIPTION
This ensures `rplaca` is called with a non-nil argument, preventing a `wrong-type-argument` error (`rplaca` expects a cons cell).

-----

The stack trace I was getting was:


> Debugger entered--Lisp error: (wrong-type-argument consp nil)
>   (smart-dash-minibuffer-install)
>   (#<subr completing-read-default> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (apply (#<subr completing-read-default> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil))
>   (#f(compiled-function (&rest app) #<bytecode -0x198371188db3d873>) #<subr completing-read-default> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (apply #f(compiled-function (&rest app) #<bytecode -0x198371188db3d873>) (#<subr completing-read-default> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil))
>   (vertico--advice #<subr completing-read-default> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (apply vertico--advice #<subr completing-read-default> ("M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil))
>   (completing-read-default "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (#<subr completing-read> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (completing-read@llama #<subr completing-read> "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (apply completing-read@llama #<subr completing-read> ("M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil))
>   (completing-read "M-x " #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_56> #f(compiled-function (sym) #<bytecode 0x5723cbd628f6eac>) t nil extended-command-history nil nil)
>   (read-extended-command-1 "M-x " nil)
>   (read-extended-command)
>   (byte-code "\302\30\11\303 \10)E\207" [execute-extended-command--last-typed current-prefix-arg nil read-extended-command] 3)
>   (command-execute execute-extended-command)
